### PR TITLE
Rename package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# `libsyncrpc`
+# `@typescript/libsyncrpc`
 
 This is a `NAPI`-based NPM package that provides synchronous IPC/RPC using a
 simple line protocol. It uses [`NAPI-RS`](https://napi.rs) under the hood. See
@@ -7,7 +7,7 @@ their site for more details as needed.
 ## Example
 
 ```typescript
-import { SyncRpcChannel } from "libsyncrpc";
+import { SyncRpcChannel } from "@typescript/libsyncrpc";
 
 const channel = new SyncRpcChannel("node", "./myscript.js");
 const DECODER = new TextDecoder();

--- a/README_tpl.md
+++ b/README_tpl.md
@@ -1,4 +1,4 @@
-# `libsyncrpc`
+# `@typescript/libsyncrpc`
 
 This is a `NAPI`-based NPM package that provides synchronous IPC/RPC using a
 simple line protocol. It uses [`NAPI-RS`](https://napi.rs) under the hood. See
@@ -7,7 +7,7 @@ their site for more details as needed.
 ## Example
 
 ```typescript
-import { SyncRpcChannel } from "libsyncrpc";
+import { SyncRpcChannel } from "@typescript/libsyncrpc";
 
 const channel = new SyncRpcChannel("node", "./myscript.js");
 const DECODER = new TextDecoder();

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        return require('libsyncrpc-android-arm64')
+        return require('@typescript/libsyncrpc-android-arm64')
       } catch (e) {
         loadErrors.push(e)
       }
@@ -86,7 +86,7 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        return require('libsyncrpc-android-arm-eabi')
+        return require('@typescript/libsyncrpc-android-arm-eabi')
       } catch (e) {
         loadErrors.push(e)
       }
@@ -102,7 +102,7 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        return require('libsyncrpc-win32-x64-msvc')
+        return require('@typescript/libsyncrpc-win32-x64-msvc')
       } catch (e) {
         loadErrors.push(e)
       }
@@ -114,7 +114,7 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        return require('libsyncrpc-win32-ia32-msvc')
+        return require('@typescript/libsyncrpc-win32-ia32-msvc')
       } catch (e) {
         loadErrors.push(e)
       }
@@ -126,7 +126,7 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        return require('libsyncrpc-win32-arm64-msvc')
+        return require('@typescript/libsyncrpc-win32-arm64-msvc')
       } catch (e) {
         loadErrors.push(e)
       }
@@ -141,7 +141,7 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        return require('libsyncrpc-darwin-universal')
+        return require('@typescript/libsyncrpc-darwin-universal')
       } catch (e) {
         loadErrors.push(e)
       }
@@ -153,7 +153,7 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        return require('libsyncrpc-darwin-x64')
+        return require('@typescript/libsyncrpc-darwin-x64')
       } catch (e) {
         loadErrors.push(e)
       }
@@ -165,7 +165,7 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        return require('libsyncrpc-darwin-arm64')
+        return require('@typescript/libsyncrpc-darwin-arm64')
       } catch (e) {
         loadErrors.push(e)
       }
@@ -181,7 +181,7 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        return require('libsyncrpc-freebsd-x64')
+        return require('@typescript/libsyncrpc-freebsd-x64')
       } catch (e) {
         loadErrors.push(e)
       }
@@ -193,7 +193,7 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        return require('libsyncrpc-freebsd-arm64')
+        return require('@typescript/libsyncrpc-freebsd-arm64')
       } catch (e) {
         loadErrors.push(e)
       }
@@ -210,7 +210,7 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        return require('libsyncrpc-linux-x64-musl')
+        return require('@typescript/libsyncrpc-linux-x64-musl')
       } catch (e) {
         loadErrors.push(e)
       }
@@ -222,7 +222,7 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        return require('libsyncrpc-linux-x64-gnu')
+        return require('@typescript/libsyncrpc-linux-x64-gnu')
       } catch (e) {
         loadErrors.push(e)
       }
@@ -236,7 +236,7 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        return require('libsyncrpc-linux-arm64-musl')
+        return require('@typescript/libsyncrpc-linux-arm64-musl')
       } catch (e) {
         loadErrors.push(e)
       }
@@ -248,7 +248,7 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        return require('libsyncrpc-linux-arm64-gnu')
+        return require('@typescript/libsyncrpc-linux-arm64-gnu')
       } catch (e) {
         loadErrors.push(e)
       }
@@ -262,7 +262,7 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        return require('libsyncrpc-linux-arm-musleabihf')
+        return require('@typescript/libsyncrpc-linux-arm-musleabihf')
       } catch (e) {
         loadErrors.push(e)
       }
@@ -274,7 +274,7 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        return require('libsyncrpc-linux-arm-gnueabihf')
+        return require('@typescript/libsyncrpc-linux-arm-gnueabihf')
       } catch (e) {
         loadErrors.push(e)
       }
@@ -288,7 +288,7 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        return require('libsyncrpc-linux-riscv64-musl')
+        return require('@typescript/libsyncrpc-linux-riscv64-musl')
       } catch (e) {
         loadErrors.push(e)
       }
@@ -300,7 +300,7 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        return require('libsyncrpc-linux-riscv64-gnu')
+        return require('@typescript/libsyncrpc-linux-riscv64-gnu')
       } catch (e) {
         loadErrors.push(e)
       }
@@ -313,7 +313,7 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        return require('libsyncrpc-linux-ppc64-gnu')
+        return require('@typescript/libsyncrpc-linux-ppc64-gnu')
       } catch (e) {
         loadErrors.push(e)
       }
@@ -325,7 +325,7 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        return require('libsyncrpc-linux-s390x-gnu')
+        return require('@typescript/libsyncrpc-linux-s390x-gnu')
       } catch (e) {
         loadErrors.push(e)
       }
@@ -350,7 +350,7 @@ if (!nativeBinding || process.env.NAPI_RS_FORCE_WASI) {
   }
   if (!nativeBinding) {
     try {
-      nativeBinding = require('libsyncrpc-wasm32-wasi')
+      nativeBinding = require('@typescript/libsyncrpc-wasm32-wasi')
     } catch (err) {
       if (process.env.NAPI_RS_FORCE_WASI) {
         loadErrors.push(err)

--- a/npm/darwin-arm64/README.md
+++ b/npm/darwin-arm64/README.md
@@ -1,3 +1,3 @@
-# `libsyncrpc-darwin-arm64`
+# `@typescript/libsyncrpc-darwin-arm64`
 
-This is the **aarch64-apple-darwin** binary for `libsyncrpc`
+This is the **aarch64-apple-darwin** binary for `@typescript/libsyncrpc`

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "libsyncrpc-darwin-arm64",
+  "name": "@typescript/libsyncrpc-darwin-arm64",
   "version": "0.0.0",
   "cpu": [
     "arm64"

--- a/npm/darwin-x64/README.md
+++ b/npm/darwin-x64/README.md
@@ -1,3 +1,3 @@
-# `libsyncrpc-darwin-x64`
+# `@typescript/libsyncrpc-darwin-x64`
 
-This is the **x86_64-apple-darwin** binary for `libsyncrpc`
+This is the **x86_64-apple-darwin** binary for `@typescript/libsyncrpc`

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "libsyncrpc-darwin-x64",
+  "name": "@typescript/libsyncrpc-darwin-x64",
   "version": "0.0.0",
   "cpu": [
     "x64"

--- a/npm/linux-arm64-gnu/README.md
+++ b/npm/linux-arm64-gnu/README.md
@@ -1,3 +1,3 @@
-# `libsyncrpc-linux-arm64-gnu`
+# `@typescript/libsyncrpc-linux-arm64-gnu`
 
-This is the **aarch64-unknown-linux-gnu** binary for `libsyncrpc`
+This is the **aarch64-unknown-linux-gnu** binary for `@typescript/libsyncrpc`

--- a/npm/linux-arm64-gnu/package.json
+++ b/npm/linux-arm64-gnu/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "libsyncrpc-linux-arm64-gnu",
+  "name": "@typescript/libsyncrpc-linux-arm64-gnu",
   "version": "0.0.0",
   "cpu": [
     "arm64"

--- a/npm/linux-arm64-musl/README.md
+++ b/npm/linux-arm64-musl/README.md
@@ -1,3 +1,3 @@
-# `libsyncrpc-linux-arm64-musl`
+# `@typescript/libsyncrpc-linux-arm64-musl`
 
-This is the **aarch64-unknown-linux-musl** binary for `libsyncrpc`
+This is the **aarch64-unknown-linux-musl** binary for `@typescript/libsyncrpc`

--- a/npm/linux-arm64-musl/package.json
+++ b/npm/linux-arm64-musl/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "libsyncrpc-linux-arm64-musl",
+  "name": "@typescript/libsyncrpc-linux-arm64-musl",
   "version": "0.0.0",
   "cpu": [
     "arm64"

--- a/npm/linux-x64-gnu/README.md
+++ b/npm/linux-x64-gnu/README.md
@@ -1,3 +1,3 @@
-# `libsyncrpc-linux-x64-gnu`
+# `@typescript/libsyncrpc-linux-x64-gnu`
 
-This is the **x86_64-unknown-linux-gnu** binary for `libsyncrpc`
+This is the **x86_64-unknown-linux-gnu** binary for `@typescript/libsyncrpc`

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "libsyncrpc-linux-x64-gnu",
+  "name": "@typescript/libsyncrpc-linux-x64-gnu",
   "version": "0.0.0",
   "cpu": [
     "x64"

--- a/npm/linux-x64-musl/README.md
+++ b/npm/linux-x64-musl/README.md
@@ -1,3 +1,3 @@
-# `libsyncrpc-linux-x64-musl`
+# `@typescript/libsyncrpc-linux-x64-musl`
 
-This is the **x86_64-unknown-linux-musl** binary for `libsyncrpc`
+This is the **x86_64-unknown-linux-musl** binary for `@typescript/libsyncrpc`

--- a/npm/linux-x64-musl/package.json
+++ b/npm/linux-x64-musl/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "libsyncrpc-linux-x64-musl",
+  "name": "@typescript/libsyncrpc-linux-x64-musl",
   "version": "0.0.0",
   "cpu": [
     "x64"

--- a/npm/win32-arm64-msvc/README.md
+++ b/npm/win32-arm64-msvc/README.md
@@ -1,3 +1,3 @@
-# `libsyncrpc-win32-arm64-msvc`
+# `@typescript/libsyncrpc-win32-arm64-msvc`
 
-This is the **aarch64-pc-windows-msvc** binary for `libsyncrpc`
+This is the **aarch64-pc-windows-msvc** binary for `@typescript/libsyncrpc`

--- a/npm/win32-arm64-msvc/package.json
+++ b/npm/win32-arm64-msvc/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "libsyncrpc-win32-arm64-msvc",
+  "name": "@typescript/libsyncrpc-win32-arm64-msvc",
   "version": "0.0.0",
   "cpu": [
     "arm64"

--- a/npm/win32-x64-msvc/README.md
+++ b/npm/win32-x64-msvc/README.md
@@ -1,3 +1,3 @@
-# `libsyncrpc-win32-x64-msvc`
+# `@typescript/libsyncrpc-win32-x64-msvc`
 
-This is the **x86_64-pc-windows-msvc** binary for `libsyncrpc`
+This is the **x86_64-pc-windows-msvc** binary for `@typescript/libsyncrpc`

--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "libsyncrpc-win32-x64-msvc",
+  "name": "@typescript/libsyncrpc-win32-x64-msvc",
   "version": "0.0.0",
   "cpu": [
     "x64"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "libsyncrpc",
+  "name": "@typescript/libsyncrpc",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "libsyncrpc",
+      "name": "@typescript/libsyncrpc",
       "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "libsyncrpc",
+  "name": "@typescript/libsyncrpc",
   "version": "0.0.0",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
The npm package `libsyncrpc` was hijacked with malware before we could publish it. Rename it so that `npm audit` and so on stop being mad ☹️ 